### PR TITLE
named protocol: fnet1

### DIFF
--- a/config/consensus.go
+++ b/config/consensus.go
@@ -1558,6 +1558,11 @@ func initConsensusProtocols() {
 	vAlpha5.ApprovedUpgrades = map[protocol.ConsensusVersion]uint64{}
 	Consensus[protocol.ConsensusVAlpha5] = vAlpha5
 	vAlpha4.ApprovedUpgrades[protocol.ConsensusVAlpha5] = 10000
+
+	// vFNetX are like vAlphaX but for AF's FNet
+	// vFnet1
+	vFnet1 := vFuture
+	Consensus[protocol.ConsensusVFnet1] = vFnet1
 }
 
 // Global defines global Algorand protocol parameters which should not be overridden.

--- a/protocol/consensus.go
+++ b/protocol/consensus.go
@@ -246,6 +246,9 @@ const ConsensusVAlpha4 = ConsensusVersion("alpha4")
 // ConsensusVAlpha5 uses the same parameters as ConsensusV36.
 const ConsensusVAlpha5 = ConsensusVersion("alpha5")
 
+// ConsensusVFnet1 uses the same parameters as Future/incentives
+const ConsensusVFnet1 = ConsensusVersion("fnet1")
+
 // !!! ********************* !!!
 // !!! *** Please update ConsensusCurrentVersion when adding new protocol versions *** !!!
 // !!! ********************* !!!


### PR DESCRIPTION
Hardcoding the current Future protocol as `fnet1` to prevent inconsistent views of the protocol in FNet.